### PR TITLE
Allow default value (false) for IsNativeToken

### DIFF
--- a/internal/models/coin.go
+++ b/internal/models/coin.go
@@ -13,7 +13,7 @@ type CoinBase struct {
 	ContractAddress string       `json:"contract_address" gorm:"type:varchar(255)"`
 	Decimals        int          `json:"decimals" binding:"required" gorm:"type:Integer;not null"`
 	PriceProviderID string       `json:"price_provider_id" gorm:"type:varchar(255)"`
-	IsNativeToken   bool         `json:"is_native_token" binding:"required"`
+	IsNativeToken   bool         `json:"is_native_token"`
 	HexPublicKey    string       `json:"hex_public_key" binding:"required" gorm:"type:varchar(255);not null"`
 	Balance         string       `json:"balance" gorm:"type:varchar(50)"`
 	PriceUSD        string       `json:"price" gorm:"type:varchar(50)"`


### PR DESCRIPTION
When we add `binding:"required"` to a field, we can't use a default value for it. I suggest we remove it for `IsNativeToken`.

