### PR TITLE
Fix vault delete

### DIFF
--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -65,7 +65,7 @@ func (a *Api) setupRouting() {
 	rg.POST("/derive-public-key", a.derivePublicKeyHandler)
 	// Vaults
 	rg.POST("/vault", a.registerVaultHandler)
-	rg.DELETE("/vault", a.deleteVaultHandler)
+	rg.DELETE("/vault/:ecdsaPublicKey/:eddsaPublicKey", a.deleteVaultHandler)
 	rg.GET("/vault/:ecdsaPublicKey/:eddsaPublicKey", a.getVaultHandler)
 	rg.POST("/vault/:ecdsaPublicKey/:eddsaPublicKey/alias", a.updateAliasHandler)
 	rg.GET("/vault/shared/:uid", a.getVaultByUIDHandler)

--- a/internal/handlers/vault_handler.go
+++ b/internal/handlers/vault_handler.go
@@ -219,14 +219,7 @@ func (a *Api) deleteVaultHandler(c *gin.Context) {
 		c.Error(errFailedToGetVault)
 		return
 	}
-	// check vault already exists , should we tell front-end that vault already registered?
-	v, err := a.s.GetVault(ecdsaPublicKey, eddsaPublicKey)
-	if err != nil {
-		a.logger.Error(err)
-		c.Error(errFailedToGetVault)
-		return
-	}
-	if v == nil {
+	if vault == nil {
 		c.Error(errVaultNotFound)
 		return
 	}

--- a/internal/handlers/vault_handler.go
+++ b/internal/handlers/vault_handler.go
@@ -206,13 +206,21 @@ func (a *Api) exitAirdrop(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 func (a *Api) deleteVaultHandler(c *gin.Context) {
-	var vault models.VaultRequest
-	if err := c.ShouldBindJSON(&vault); err != nil {
-		c.Error(errInvalidRequest)
+	ecdsaPublicKey := c.Param("ecdsaPublicKey")
+	eddsaPublicKey := c.Param("eddsaPublicKey")
+	hexChainCode := c.GetHeader("x-hex-chain-code")
+	if hexChainCode == "" {
+		c.Error(errForbiddenAccess)
+		return
+	}
+	vault, err := a.s.GetVault(ecdsaPublicKey, eddsaPublicKey)
+	if err != nil {
+		a.logger.Error(err)
+		c.Error(errFailedToGetVault)
 		return
 	}
 	// check vault already exists , should we tell front-end that vault already registered?
-	v, err := a.s.GetVault(vault.PublicKeyECDSA, vault.PublicKeyEDDSA)
+	v, err := a.s.GetVault(ecdsaPublicKey, eddsaPublicKey)
 	if err != nil {
 		a.logger.Error(err)
 		c.Error(errFailedToGetVault)
@@ -222,12 +230,15 @@ func (a *Api) deleteVaultHandler(c *gin.Context) {
 		c.Error(errVaultNotFound)
 		return
 	}
-	if v.HexChainCode == vault.HexChainCode && v.Uid == vault.Uid {
-		if err := a.s.DeleteVault(vault.PublicKeyECDSA, vault.PublicKeyEDDSA); err != nil {
+	if hexChainCode == vault.HexChainCode {
+		if err := a.s.DeleteVault(ecdsaPublicKey, eddsaPublicKey); err != nil {
 			a.logger.Error(err)
 			c.Error(errFailedToDeleteVault)
 			return
 		}
+	} else {
+		c.Error(errForbiddenAccess)
+		return
 	}
 	c.Status(http.StatusOK)
 }


### PR DESCRIPTION
According to the HTTP/1.1 specification (RFC 7231), an HTTP DELETE request does not typically have a body. The standard assumes that the resource to be deleted is fully identified by the request URI, and no additional information in the body is needed.

Some browsers and JavaScript libraries (e.g., older Android WebView versions or certain JavaScript APIs) may strip or reject the body altogether, leading to unexpected behaviors.