### PR TITLE
Added rKujira Balance

### DIFF
--- a/internal/balance/balance_test.go
+++ b/internal/balance/balance_test.go
@@ -56,8 +56,13 @@ func TestGetUtxoBalances(t *testing.T) {
 	balance, err = b.FetchDydxBalanceOfAddress("dydx1jl8v454zpnjz76djzdydeq8gwk9364gjlqrs3l")
 	assert.Nil(t, err)
 	fmt.Println("dydx1jl8v454zpnjz76djzdydeq8gwk9364gjlqrs3l:", balance)
+	
 	balance, err = b.FetchKujiraBalanceOfAddress("kujira153nnvyxz66sj4ywldvy0uexhdnwpfw9fyf4nkz")
 	assert.Nil(t, err)
 	fmt.Println("kujira153nnvyxz66sj4ywldvy0uexhdnwpfw9fyf4nkz", balance)
+	
+	balance, err = b.FetchRkujiraBalanceOfAddress("kujira1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8khxyy4")
+	assert.Nil(t, err)
+	fmt.Println("kujira1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8khxyy4", balance)
 
 }

--- a/internal/balance/cosmos.go
+++ b/internal/balance/cosmos.go
@@ -89,6 +89,11 @@ func (b *BalanceResolver) FetchKujiraBalanceOfAddress(address string) (float64, 
 	return b.fetchSpecificCosmosBalance(url, "ukuji", 6)
 }
 
+func (b *BalanceResolver) FetchRkujiraBalanceOfAddress(address string) (float64, error) {
+	url := fmt.Sprintf("https://kujira-rest.publicnode.com/cosmos/bank/v1beta1/balances/%s", address)
+	return b.fetchSpecificCosmosBalance(url, "factory/kujira1tsekaqv9vmem0zwskmf90gpf0twl6k57e8vdnq/urkuji", 6)
+}
+
 func (b *BalanceResolver) FetchDydxBalanceOfAddress(address string) (float64, error) {
 	url := fmt.Sprintf("https://dydx-rest.publicnode.com/cosmos/bank/v1beta1/balances/%s", address)
 	return b.fetchSpecificCosmosBalance(url, "adydx", 18)


### PR DESCRIPTION
- Copied the Kujira one
- Renamed it
- Added the factory
- Added a test

Note: I just ran the test functionality, not the whole app - so I may have missed something. 
Note: I know I didnt incorporate it in the entire thing such as as [GetBalance](https://github.com/vultisig/airdrop-registry/blob/de45decaf22540481e9e5331cff399bb1eb2d5e5/internal/balance/balance.go#L56C27-L56C37) because I was also unsure how the $$ is going to be retrieved in the cmcMap. I also didn't know if its okay that its just in this repo vs getting it in the main app as a token underneath Kujira. Didn't want to put a lot of effort into it because the chain is getting merged into the App Layer, so it kind of becomes temporary work

From this thread: https://x.com/jpthor/status/1843218512791367765

Test results before change:
```
=== RUN   TestGetUtxoBalances
Solana balance H7FmBYGBi5EmbJaKA88yBgmyGm7eSFdkzCtigwkeaXxb: 0.444591999
SUI balance for 0x156e6f6a3f8615008b79dd4871f658ec0da6d70a8540d9dd4d12023b8017e638: 0.10020136
ETH balance for 0x07773707BdA78aC4052f736544928b15dD31c5cc: 0.01999184952064041
USDT balance for 0x07773707BdA78aC4052f736544928b15dD31c5cc: 25.512098
24147
15.24327669
thor1tgxm5jw6hrlvslrd6lqpk4jwuu4g29dxytrean: 2.65637803
thor13amyx54c7z8vfhtd4fhghl30rz2v4t0hdsuk6w: 0
maya1h5rlf94hqkvvkyzyhmmgw0hdtw200nqjmaymqc: 0
maya1vzltn37rqccwk95tny657au9j2z072dhg845dr: 22.2573282492
cosmos1jl8v454zpnjz76djzdydeq8gwk9364gjked53g: 0.100491
dydx1jl8v454zpnjz76djzdydeq8gwk9364gjlqrs3l: 1.285
kujira153nnvyxz66sj4ywldvy0uexhdnwpfw9fyf4nkz 0.748854
--- PASS: TestGetUtxoBalances (2.41s)
```

Test results after change:
```
=== RUN   TestGetUtxoBalances
Solana balance H7FmBYGBi5EmbJaKA88yBgmyGm7eSFdkzCtigwkeaXxb: 0.444591999
SUI balance for 0x156e6f6a3f8615008b79dd4871f658ec0da6d70a8540d9dd4d12023b8017e638: 0.10020136
ETH balance for 0x07773707BdA78aC4052f736544928b15dD31c5cc: 0.01999184952064041
USDT balance for 0x07773707BdA78aC4052f736544928b15dD31c5cc: 25.512098
24147
15.24786462
thor1tgxm5jw6hrlvslrd6lqpk4jwuu4g29dxytrean: 2.65637803
thor13amyx54c7z8vfhtd4fhghl30rz2v4t0hdsuk6w: 0
maya1h5rlf94hqkvvkyzyhmmgw0hdtw200nqjmaymqc: 0
maya1vzltn37rqccwk95tny657au9j2z072dhg845dr: 22.2573282492
cosmos1jl8v454zpnjz76djzdydeq8gwk9364gjked53g: 0.100491
dydx1jl8v454zpnjz76djzdydeq8gwk9364gjlqrs3l: 1.285
kujira153nnvyxz66sj4ywldvy0uexhdnwpfw9fyf4nkz 0.748854
**kujira1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8khxyy4 27.337689**
--- PASS: TestGetUtxoBalances (3.97s)
```


https://finder.kujira.network/kaiyo-1/address/kujira1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8khxyy4

![rkujira](https://github.com/user-attachments/assets/e89f0b33-1749-4546-9499-93e22502fdfb)


