### PR TITLE
Add leader board dashboard api

### DIFF
--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -82,6 +82,7 @@ func (a *Api) setupRouting() {
 	rg.POST("vault/theme", a.updateVaultShareAppearanceHandler)
 
 	// leader board
+	rg.GET("/leaderboard/vaults", a.getVaultsByRankHandler)
 
 }
 

--- a/internal/handlers/vault_handler.go
+++ b/internal/handlers/vault_handler.go
@@ -201,6 +201,7 @@ func (a *Api) exitAirdrop(c *gin.Context) {
 	}
 	if v.HexChainCode == vault.HexChainCode && v.Uid == vault.Uid {
 		v.JoinAirdrop = false
+		v.Rank = 0
 		if err := a.s.UpdateVault(v); err != nil {
 			a.logger.Error(err)
 			_ = c.Error(errFailedToExitRegistry)

--- a/internal/models/vault_resp.go
+++ b/internal/models/vault_resp.go
@@ -9,5 +9,11 @@ type VaultResponse struct {
 	PublicKeyEDDSA string       `json:"public_key_eddsa"`
 	TotalPoints    float64      `json:"total_points"`
 	JoinAirdrop    bool         `json:"join_airdrop"`
+	Rank           int64        `json:"rank"`
 	Coins          []ChainCoins `json:"chains"`
+}
+
+type VaultsResponse struct {
+	Vaults          []VaultResponse `json:"vaults"`
+	TotalVaultCount int64           `json:"total_vault_count"`
 }

--- a/internal/services/vault_service.go
+++ b/internal/services/vault_service.go
@@ -62,3 +62,20 @@ func (s *Storage) DeleteVault(ecdsa, eddsa string) error {
 
 	return nil
 }
+
+func (s *Storage) GetLeaderVaults(fromRank int64, limit int) ([]models.Vault, error) {
+	var vaults []models.Vault
+	// where rank is not null and rank > fromRank
+	if err := s.db.Where("`rank` is not null and `rank` > ?", fromRank).Order("`rank` asc").Limit(limit).Find(&vaults).Error; err != nil {
+		return nil, fmt.Errorf("failed to get leader vaults: %w", err)
+	}
+	return vaults, nil
+}
+
+func (s *Storage) GetLeaderVaultCount() (int64, error) {
+	var count int64
+	if err := s.db.Model(&models.Vault{}).Where("`rank` is not null").Count(&count).Error; err != nil {
+		return 0, fmt.Errorf("failed to get leader vault count: %w", err)
+	}
+	return count, nil
+}


### PR DESCRIPTION
- I assumed that at the end of each day, after calculating points of all vaults, we will calculate the rank of each vault (starting from 1). This way, we can fetch vaults ordered by rank in ascending order to get the top vaults.

- If a user has not registered for the airdrop or has removed their vault from the airdrop registry, we will set their vault's rank to 0.