### PR TITLE
combine kujira and rkujira balance as the "same"

### DIFF
--- a/internal/balance/balance.go
+++ b/internal/balance/balance.go
@@ -73,7 +73,10 @@ func (b *BalanceResolver) GetBalance(coin models.CoinDBModel) (float64, error) {
 	case common.Dydx:
 		return b.FetchDydxBalanceOfAddress(coin.Address)
 	case common.Kujira:
-		return b.FetchKujiraBalanceOfAddress(coin.Address)
+		balanceKujira, nil := b.FetchKujiraBalanceOfAddress(coin.Address)
+		balanceRkujira, nil := b.FetchRkujiraBalanceOfAddress(coin.Address)
+		totalBalance := balanceKujira + balanceRkujira
+		return totalBalance, nil
 	case common.Solana:
 		return b.FetchSolanaBalanceOfAddress(coin.Address)
 	case common.Polkadot:

--- a/internal/balance/balance.go
+++ b/internal/balance/balance.go
@@ -73,9 +73,15 @@ func (b *BalanceResolver) GetBalance(coin models.CoinDBModel) (float64, error) {
 	case common.Dydx:
 		return b.FetchDydxBalanceOfAddress(coin.Address)
 	case common.Kujira:
-		balanceKujira, nil := b.FetchKujiraBalanceOfAddress(coin.Address)
-		balanceRkujira, nil := b.FetchRkujiraBalanceOfAddress(coin.Address)
-		totalBalance := balanceKujira + balanceRkujira
+		var totalBalance float64
+		balanceKujira, errK := b.FetchKujiraBalanceOfAddress(coin.Address)
+		if errK == nil {
+			totalBalance += balanceKujira
+		}
+		balanceRkujira, errR := b.FetchRkujiraBalanceOfAddress(coin.Address)
+		if errR == nil {
+			totalBalance += balanceRkujira
+		}
 		return totalBalance, nil
 	case common.Solana:
 		return b.FetchSolanaBalanceOfAddress(coin.Address)


### PR DESCRIPTION
This is an extension of https://github.com/vultisig/airdrop-registry/pull/56 .

I didn't add the balances together because I wasn't sure if there was a different model you wanted to do with it. 

I don't know if this is the best approach but figured I would add it anyways in case its the path the group wants to go.

from the original pr

> Note: I know I didnt incorporate it in the entire thing such as as [GetBalance](https://github.com/vultisig/airdrop-registry/blob/de45decaf22540481e9e5331cff399bb1eb2d5e5/internal/balance/balance.go#L56C27-L56C37) because I was also unsure how the $$ is going to be retrieved in the cmcMap. I also didn't know if its okay that its just in this repo vs getting it in the main app as a token underneath Kujira. Didn't want to put a lot of effort into it because the chain is getting merged into the App Layer, so it kind of becomes temporary work

Tweeted at jpthor to see if it helps - https://x.com/DorianKersch/status/1845461207483834596

Note: Anyone that puts rKuji in vultisig cannot withdraw it at the moment because there is no support for multiple tokens on Kujira atm - but at least they can get airdrop points with this PR...

