### PR TITLE
Hotfix: Ensure eth_call Uses "latest" for ERC-20 Balance Queries

### DIFF
--- a/internal/balance/erc20.go
+++ b/internal/balance/erc20.go
@@ -58,6 +58,7 @@ func (b *BalanceResolver) fetchERC20TokenBalance(chain common.Chain, contractAdd
 			To:   contractAddress,
 			Data: data,
 		},
+		"latest",
 	}
 
 	// Create RPC request


### PR DESCRIPTION
**Issue:**
- Some ERC-20 tokens (like WBTC) require "latest" in the RPC call, while others do not.
- This inconsistency causes failures in balance retrieval for certain tokens.

**Fix:**
- Updated the eth_call implementation to always include "latest" as the block parameter.
- Ensures uniform behavior across all tokens and RPC providers.