### PR TITLE
 Enforce EIP-55 checksum format for contract addresses in CMC API

### DIFF
--- a/internal/tokens/cmcid_service.go
+++ b/internal/tokens/cmcid_service.go
@@ -131,7 +131,7 @@ func (c *CMCService) GetCMCIDByContract(chainName, contract string) (int, error)
 	}
 
 	//if chain is EVM, then convert to checksum address
-	if utils.IsETHAddress(strings.TrimPrefix(contract, "0x")) {
+	if utils.IsETHAddress(contract) {
 		contractEIP55, err := utils.EIP55Checksum(contract)
 		if err != nil {
 			return -1, fmt.Errorf("failed to convert contract address to EIP55 checksum: %w", err)

--- a/internal/tokens/cmcid_service.go
+++ b/internal/tokens/cmcid_service.go
@@ -131,7 +131,7 @@ func (c *CMCService) GetCMCIDByContract(chainName, contract string) (int, error)
 	}
 
 	//if chain is EVM, then convert to checksum address
-	if utils.IsValidHex(strings.TrimPrefix(contract, "0x")) {
+	if utils.IsETHAddress(strings.TrimPrefix(contract, "0x")) {
 		contractEIP55, err := utils.EIP55Checksum(contract)
 		if err != nil {
 			return -1, fmt.Errorf("failed to convert contract address to EIP55 checksum: %w", err)

--- a/internal/tokens/cmcid_service.go
+++ b/internal/tokens/cmcid_service.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/vultisig/airdrop-registry/internal/common"
 	"github.com/vultisig/airdrop-registry/internal/models"
+	"github.com/vultisig/airdrop-registry/internal/utils"
 )
 
 var cmcChainMap map[common.Chain]string = map[common.Chain]string{
@@ -119,8 +120,8 @@ func (c *CMCService) GetCMCID(chain common.Chain, coin models.Coin) (int, error)
 	return c.GetCMCIDByContract(cmcChainMap[chain], coin.ContractAddress)
 }
 
-func (c *CMCService) GetCMCIDByContract(chain, contract string) (int, error) {
-	if cachedData, found := c.cachedData.Get(c.getCacheKey(chain, contract)); found {
+func (c *CMCService) GetCMCIDByContract(chainName, contract string) (int, error) {
+	if cachedData, found := c.cachedData.Get(c.getCacheKey(chainName, contract)); found {
 		if cmcID, ok := cachedData.(int); ok {
 			return cmcID, nil
 		}
@@ -128,6 +129,16 @@ func (c *CMCService) GetCMCIDByContract(chain, contract string) (int, error) {
 	if contract == "" {
 		return 0, fmt.Errorf("empty contract address provided")
 	}
+
+	//if chain is EVM, then convert to checksum address
+	if utils.IsValidHex(strings.TrimPrefix(contract, "0x")) {
+		contractEIP55, err := utils.EIP55Checksum(contract)
+		if err != nil {
+			return -1, fmt.Errorf("failed to convert contract address to EIP55 checksum: %w", err)
+		}
+		contract = contractEIP55
+	}
+
 	url := fmt.Sprintf("%s/info?address=%s&skip_invalid=true&aux=status", c.baseURL, contract)
 	resp, err := http.Get(url)
 	if err != nil {
@@ -143,7 +154,7 @@ func (c *CMCService) GetCMCIDByContract(chain, contract string) (int, error) {
 	}
 	for _, v := range cmcContractModel.Data {
 		for _, ca := range v.ContractAddresses {
-			if strings.EqualFold(ca.ContractAddress, contract) && ca.Platform.Coin.Name == chain {
+			if strings.EqualFold(ca.ContractAddress, contract) && ca.Platform.Coin.Name == chainName {
 				c.cachedData.Set(c.getCacheKey(ca.Platform.Name, contract), v.ID, cache.DefaultExpiration)
 				return v.ID, nil
 			}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -18,6 +18,10 @@ func IsValidHex(s string) bool {
 	re := regexp.MustCompile(`^[0-9a-fA-F]{64,66}$`)
 	return re.MatchString(s)
 }
+func IsETHAddress(s string) bool {
+	re := regexp.MustCompile(`^0x[a-fA-F0-9]{40}$`)
+	return re.MatchString(s)
+}
 
 func HexToFloat64(hexStr string, decimals int64) (float64, error) {
 	if strings.HasPrefix(hexStr, "0x") {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/mr-tron/base58"
@@ -19,8 +20,7 @@ func IsValidHex(s string) bool {
 	return re.MatchString(s)
 }
 func IsETHAddress(s string) bool {
-	re := regexp.MustCompile(`^0x[a-fA-F0-9]{40}$`)
-	return re.MatchString(s)
+	return common.IsHexAddress(s)
 }
 
 func HexToFloat64(hexStr string, decimals int64) (float64, error) {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/mr-tron/base58"
 )
 
@@ -84,24 +83,9 @@ func NewJsonRPCRequest(method string, params interface{}, id int) map[string]int
 }
 
 func EIP55Checksum(address string) (string, error) {
-	address = strings.ToLower(strings.TrimPrefix(address, "0x"))
-	hash := crypto.Keccak256Hash([]byte(address)).Hex()[2:] // remove '0x' from hash
-
-	var result strings.Builder
-	result.WriteString("0x")
-
-	for i := 0; i < len(address); i++ {
-		char := address[i]
-		hashChar := hash[i]
-
-		if char >= '0' && char <= '9' {
-			result.WriteByte(char)
-		} else if hashChar >= '8' {
-			result.WriteByte(byte(strings.ToUpper(string(char))[0]))
-		} else {
-			result.WriteByte(char)
-		}
+	if !IsETHAddress(address) {
+		return "", fmt.Errorf("invalid address")
 	}
-
-	return result.String(), nil
+	addr := common.HexToAddress(address)
+	return addr.Hex(), nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/mr-tron/base58"
 )
 
@@ -76,4 +77,27 @@ func NewJsonRPCRequest(method string, params interface{}, id int) map[string]int
 		"params":  params,
 		"id":      id,
 	}
+}
+
+func EIP55Checksum(address string) (string, error) {
+	address = strings.ToLower(strings.TrimPrefix(address, "0x"))
+	hash := crypto.Keccak256Hash([]byte(address)).Hex()[2:] // remove '0x' from hash
+
+	var result strings.Builder
+	result.WriteString("0x")
+
+	for i := 0; i < len(address); i++ {
+		char := address[i]
+		hashChar := hash[i]
+
+		if char >= '0' && char <= '9' {
+			result.WriteByte(char)
+		} else if hashChar >= '8' {
+			result.WriteByte(byte(strings.ToUpper(string(char))[0]))
+		} else {
+			result.WriteByte(char)
+		}
+	}
+
+	return result.String(), nil
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -59,19 +59,61 @@ func TestHexToFloat64(t *testing.T) {
 }
 
 func TestEIP55(t *testing.T) {
-	contracts := make([]string, 0)
-	contracts = append(contracts, "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b",
-		"0x5947bb275c521040051d82396192181b413227a3",
-		"0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
-		"tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t",
-		"0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
-		"es9vmfrzacermjfrf4h2fyd4kconky11mcce8benwnyb",
-	)
+	testCases := []struct {
+		name           string
+		input          string
+		expectedOutput string
+		expectError    bool
+	}{
+		{
+			name:           "Valid lowercase address",
+			input:          "0x5aeda56215b167893e80b4fe645ba6d5bab767de",
+			expectedOutput: "0x5AEDA56215b167893e80B4fE645BA6d5Bab767DE",
+			expectError:    false,
+		},
+		{
+			name:           "Valid uppercase address",
+			input:          "0X5AEDA56215B167893E80B4FE645BA6D5BAB767DE",
+			expectedOutput: "0x5AEDA56215b167893e80B4fE645BA6d5Bab767DE",
+			expectError:    false,
+		},
+		{
+			name:           "Address with mixed case",
+			input:          "0x5aeDa56215b167893e80B4fE645BA6d5Bab767DE",
+			expectedOutput: "0x5AEDA56215b167893e80B4fE645BA6d5Bab767DE",
+			expectError:    false,
+		},
+		{
+			name:        "Invalid address - too short",
+			input:       "0x5aeda56215b167",
+			expectError: true,
+		},
+		{
+			name:        "Invalid address - non-hex characters",
+			input:       "0xZZeda56215b167893e80b4fe645ba6d5bab767de",
+			expectError: true,
+		},
+	}
 
-	for _, contract := range contracts {
-		_, err := EIP55Checksum(contract)
-		if err != nil {
-			t.Errorf("Failed to get EIP55 checksum for %s: %v", contract, err)
-		}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := EIP55Checksum(tc.input)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error for input %s, but got none", tc.input)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("Did not expect error for input %s, but got: %v", tc.input, err)
+				return
+			}
+
+			if actual != tc.expectedOutput {
+				t.Errorf("For input %s, expected output %s, but got %s", tc.input, tc.expectedOutput, actual)
+			}
+		})
 	}
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -57,3 +57,21 @@ func TestHexToFloat64(t *testing.T) {
 		}
 	}
 }
+
+func TestEIP55(t *testing.T) {
+	contracts := make([]string, 0)
+	contracts = append(contracts, "0x0b3e328455c4059eeb9e3f84b5543f74e24e7e1b",
+		"0x5947bb275c521040051d82396192181b413227a3",
+		"0x23ee2343b892b1bb63503a4fabc840e0e2c6810f",
+		"tr7nhqjekqxgtci8q8zy4pl8otszgjlj6t",
+		"0xfd086bc7cd5c481dcc9c85ebe478a1c0b69fcbb9",
+		"es9vmfrzacermjfrf4h2fyd4kconky11mcce8benwnyb",
+	)
+
+	for _, contract := range contracts {
+		_, err := EIP55Checksum(contract)
+		if err != nil {
+			t.Errorf("Failed to get EIP55 checksum for %s: %v", contract, err)
+		}
+	}
+}


### PR DESCRIPTION

Fix #135 

This PR adds validation to ensure that all contract addresses passed to the `/cmc/v1/cryptocurrency/info `endpoint conform to the EIP-55 checksum standard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved validation and normalization of Ethereum contract addresses to use EIP-55 checksum format.
- **Bug Fixes**
	- Enhanced parameter naming consistency for better clarity in address handling.
- **Tests**
	- Added tests to verify the checksum conversion of Ethereum addresses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->