### PR TITLE
Add quest service for cmc

### DIFF
--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -26,7 +26,7 @@ type Api struct {
 	s            *services.Storage
 	router       *gin.Engine
 	cachedData   *cache.Cache
-	questService QuestService
+	questService *QuestService
 }
 
 // NewApi creates a new Api instance

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -21,11 +21,12 @@ import (
 
 // Api is the main handler for the API
 type Api struct {
-	logger     *logrus.Logger
-	cfg        *config.Config
-	s          *services.Storage
-	router     *gin.Engine
-	cachedData *cache.Cache
+	logger       *logrus.Logger
+	cfg          *config.Config
+	s            *services.Storage
+	router       *gin.Engine
+	cachedData   *cache.Cache
+	questService QuestService
 }
 
 // NewApi creates a new Api instance
@@ -36,12 +37,17 @@ func NewApi(cfg *config.Config, s *services.Storage) (*Api, error) {
 	if nil == s {
 		return nil, fmt.Errorf("storage is nil")
 	}
+	questService, err := NewQuestService(s)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create quest service: %w", err)
+	}
 	return &Api{
-		cfg:        cfg,
-		s:          s,
-		router:     gin.Default(),
-		logger:     logrus.WithField("module", "api").Logger,
-		cachedData: cache.New(5*time.Minute, 10*time.Minute),
+		cfg:          cfg,
+		s:            s,
+		router:       gin.Default(),
+		logger:       logrus.WithField("module", "api").Logger,
+		cachedData:   cache.New(5*time.Minute, 10*time.Minute),
+		questService: questService,
 	}, nil
 }
 
@@ -99,6 +105,9 @@ func (a *Api) setupRouting() {
 	rg.GET("/seasons/info", a.getAllSeasonInfo)
 	// new endpoint for fetching total points of a season
 	rg.GET("/seasons/points/:seasonID", a.getTotalPointsBySeasonHandler)
+
+	// coinmarketcap quest
+	rg.GET("/cmc/quest/verify", a.verifyCoinMarketCapQuest)
 
 }
 

--- a/internal/handlers/cmc.go
+++ b/internal/handlers/cmc.go
@@ -1,0 +1,23 @@
+package handlers
+
+import "github.com/gin-gonic/gin"
+
+type cmcQuestResponse struct {
+	Result struct {
+		IsValid bool `json:"is_valid"`
+	} `json:"result"`
+}
+
+func (a *Api) verifyCoinMarketCapQuest(c *gin.Context) {
+	address := c.Query("address")
+	isValid := a.questService.Exists(address)
+
+	result := cmcQuestResponse{
+		Result: struct {
+			IsValid bool `json:"is_valid"`
+		}{
+			IsValid: isValid,
+		},
+	}
+	c.JSON(200, result)
+}

--- a/internal/handlers/cmc.go
+++ b/internal/handlers/cmc.go
@@ -9,6 +9,7 @@ type cmcQuestResponse struct {
 }
 
 func (a *Api) verifyCoinMarketCapQuest(c *gin.Context) {
+	//TODO: add whitelist ip address check for cmc
 	address := c.Query("address")
 	isValid := a.questService.Exists(address)
 

--- a/internal/handlers/quest_service.go
+++ b/internal/handlers/quest_service.go
@@ -1,0 +1,124 @@
+package handlers
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"github.com/vultisig/airdrop-registry/internal/common"
+	"github.com/vultisig/airdrop-registry/internal/models"
+	"github.com/vultisig/airdrop-registry/internal/services"
+)
+
+// store eth address of all vaults in memory (for 10K vaults, it will take around 800KB of memory)
+type QuestService struct {
+	sync.RWMutex
+	logger          *logrus.Logger
+	storage         *services.Storage
+	ethAddressStore map[string]uint
+}
+
+func NewQuestService(storage *services.Storage) (QuestService, error) {
+	questService := QuestService{
+		logger:          logrus.WithField("module", "quest_service").Logger,
+		storage:         storage,
+		ethAddressStore: make(map[string]uint),
+	}
+	if err := questService.initialize(); err != nil {
+		return QuestService{}, err
+	}
+	return questService, nil
+}
+
+// initialize the quest service
+// step1: Try to fetch all eth address from coin store
+// step2: Try to generate missing eth address from vaults
+func (q *QuestService) initialize() error {
+	q.Lock()
+	defer q.Unlock()
+	q.ethAddressStore = make(map[string]uint)
+
+	//step1
+	var coinPageId uint64
+	for {
+		coins, err := q.storage.GetCoinsWithPage(coinPageId, 10000)
+		if err != nil {
+			return err
+		}
+		if coinPageId > 0 {
+			break
+		}
+		if len(coins) == 0 {
+			break
+		}
+		coinPageId = uint64(coins[len(coins)-1].ID + 1)
+		for _, coin := range coins {
+			for _, evmChain := range common.EVMChains {
+				if coin.Chain == evmChain {
+					q.ethAddressStore[coin.Address] = coin.VaultID
+					break
+				}
+			}
+		}
+	}
+
+	//step2
+	var vaultPageId uint
+	for {
+		vaults, err := q.storage.GetVaultsWithPage(vaultPageId, 1000)
+		if err != nil {
+			return err
+		}
+		if len(vaults) == 0 {
+			break
+		}
+		if vaultPageId > 0 {
+			break
+		}
+		vaultPageId = vaults[len(vaults)-1].ID + 1
+		for _, vault := range vaults {
+			exits := false
+			for _, v := range q.ethAddressStore {
+				if v == vault.ID {
+					exits = true
+					break
+				}
+			}
+			if !exits {
+				//generate eth address from vault
+				ethAddress, err := vault.GetAddress(common.Ethereum)
+				if err != nil {
+					q.logger.Errorf("failed to get eth address for vault %d: %v", vault.ID, err)
+					continue
+				}
+				q.ethAddressStore[ethAddress] = vault.ID
+			}
+		}
+	}
+	return nil
+}
+
+func (q *QuestService) Exists(ethAddress string) bool {
+	q.RLock()
+	defer q.RUnlock()
+	_, exists := q.ethAddressStore[ethAddress]
+	return exists
+}
+
+func (q *QuestService) Add(vault models.Vault) {
+	q.Lock()
+	defer q.Unlock()
+	ethAddress, err := vault.GetAddress(common.Ethereum)
+	if err == nil {
+		q.ethAddressStore[ethAddress] = vault.ID
+	}
+}
+
+func (q *QuestService) Remove(vaultId uint) {
+	q.Lock()
+	defer q.Unlock()
+	for ethAddress, id := range q.ethAddressStore {
+		if id == vaultId {
+			delete(q.ethAddressStore, ethAddress)
+		}
+	}
+}

--- a/internal/handlers/quest_service.go
+++ b/internal/handlers/quest_service.go
@@ -17,16 +17,16 @@ type QuestService struct {
 	ethAddressStore map[string]uint
 }
 
-func NewQuestService(storage *services.Storage) (QuestService, error) {
+func NewQuestService(storage *services.Storage) (*QuestService, error) {
 	questService := QuestService{
 		logger:          logrus.WithField("module", "quest_service").Logger,
 		storage:         storage,
 		ethAddressStore: make(map[string]uint),
 	}
 	if err := questService.initialize(); err != nil {
-		return QuestService{}, err
+		return &QuestService{}, err
 	}
-	return questService, nil
+	return &questService, nil
 }
 
 // initialize the quest service
@@ -43,9 +43,6 @@ func (q *QuestService) initialize() error {
 		coins, err := q.storage.GetCoinsWithPage(coinPageId, 10000)
 		if err != nil {
 			return err
-		}
-		if coinPageId > 0 {
-			break
 		}
 		if len(coins) == 0 {
 			break
@@ -71,19 +68,16 @@ func (q *QuestService) initialize() error {
 		if len(vaults) == 0 {
 			break
 		}
-		if vaultPageId > 0 {
-			break
-		}
 		vaultPageId = vaults[len(vaults)-1].ID + 1
 		for _, vault := range vaults {
-			exits := false
+			exists := false
 			for _, v := range q.ethAddressStore {
 				if v == vault.ID {
-					exits = true
+					exists = true
 					break
 				}
 			}
-			if !exits {
+			if !exists {
 				//generate eth address from vault
 				ethAddress, err := vault.GetAddress(common.Ethereum)
 				if err != nil {

--- a/internal/handlers/vault_handler.go
+++ b/internal/handlers/vault_handler.go
@@ -46,6 +46,7 @@ func (a *Api) registerVaultHandler(c *gin.Context) {
 		_ = c.Error(errFailedToRegisterVault)
 		return
 	}
+	a.questService.Add(vaultModel)
 	c.Status(http.StatusCreated)
 }
 
@@ -313,6 +314,7 @@ func (a *Api) deleteVaultHandler(c *gin.Context) {
 		_ = c.Error(errForbiddenAccess)
 		return
 	}
+	a.questService.Remove(vault.ID)
 	c.Status(http.StatusOK)
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint to verify the existence of Ethereum addresses for CoinMarketCap quests.
  * Introduced support for managing and validating Ethereum addresses associated with vaults.
* **Enhancements**
  * Vault registration and deletion now automatically update the quest verification service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->