### PR TITLE
Fix typo in token ticker for rujira

### DIFF
--- a/internal/tokens/predefined_tokens.json
+++ b/internal/tokens/predefined_tokens.json
@@ -796,6 +796,6 @@
     "cmc_id": 0,
     "contract_address": "",
     "decimals": 8,
-    "ticker": "rujia"
+    "ticker": "rujira"
   }
 ]


### PR DESCRIPTION
@aminsato - i think there was a typo in the last PR - so i submitted this. Feel free to use it or ignore it. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the ticker name for a THORChain token from "rujia" to "rujira".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->